### PR TITLE
fix: do not require to always provide in root

### DIFF
--- a/lib/xstate-ngx/src/lib/useActor.ts
+++ b/lib/xstate-ngx/src/lib/useActor.ts
@@ -27,7 +27,7 @@ import type { AnyMachineSnapshot } from 'xstate/dist/declarations/src/types';
  */
 export function useActor<TLogic extends AnyActorLogic>(
   actorLogic: TLogic,
-  _options?: ActorOptions<TLogic> & { providedIn: 'root' }
+  _options?: ActorOptions<TLogic> & { providedIn?: 'root' }
 ): Type<ActorStoreProps<TLogic>> {
   const { providedIn, ...options } = _options ?? {};
 


### PR DESCRIPTION
This typing was forcing the `{ provideIn: 'root', ..}` always
but we could just leave it empty to provide it in a Component or Route.