### PR TITLE
feat: support ActorLogic factories to be able to inject services

### DIFF
--- a/lib/xstate-ngx/src/lib/useActor.ts
+++ b/lib/xstate-ngx/src/lib/useActor.ts
@@ -26,7 +26,7 @@ import type { AnyMachineSnapshot } from 'xstate/dist/declarations/src/types';
  * @return The Angular service that provides the actor store.
  */
 export function useActor<TLogic extends AnyActorLogic>(
-  actorLogic: TLogic,
+  actorLogic: TLogic | (() => TLogic),
   _options?: ActorOptions<TLogic> & { providedIn: 'root' }
 ): Type<ActorStoreProps<TLogic>> {
   const { providedIn, ...options } = _options ?? {};
@@ -44,8 +44,9 @@ export function useActor<TLogic extends AnyActorLogic>(
       const listener = (nextSnapshot: Snapshot<unknown>) => {
         this._snapshot?.set(nextSnapshot as any);
       };
+      const resolvedLogic = actorLogic instanceof Function ? actorLogic() : actorLogic;
 
-      this.actorRef = useActorRef(actorLogic, options, listener);
+      this.actorRef = useActorRef(resolvedLogic, options, listener);
       this._snapshot = signal(this.actorRef.getSnapshot());
       this.send = this.actorRef.send;
       this.snapshot = this._snapshot.asReadonly();

--- a/lib/xstate-ngx/src/lib/useMachine.ts
+++ b/lib/xstate-ngx/src/lib/useMachine.ts
@@ -13,7 +13,7 @@ import { useActor } from './useActor';
  * @alias useActor
  */
 export function useMachine<TMachine extends AnyStateMachine>(
-  actorLogic: TMachine,
+  actorLogic: TMachine | (() => TMachine),
   options?: ActorOptions<TMachine> & { providedIn: 'root' }
 ) {
   return useActor(actorLogic, options);


### PR DESCRIPTION
Running the Logic inside a Factory gives us the possibility to `inject` stuff like:
```ts
  context: {
    router: inject(Router),
  },
```
or having the services in the factory closure like:
```ts
() => {
  const service = inject(AngularService);

  return createMachine({
    entry: () => {
      service.initialize();
    },
  })
}
```
a new layer to handle the Angular injections.